### PR TITLE
Fix for clicking into "No action possible" in Assigned Quiz

### DIFF
--- a/src/containers/Main/AssignedQuiz/AssignedQuiz.js
+++ b/src/containers/Main/AssignedQuiz/AssignedQuiz.js
@@ -30,10 +30,13 @@ const AssignedQuiz = () => {
 
     const navigate = useNavigate();
 
-    const clickHandler = (quizId) => (event) => {
+    const clickHandler = (quizId, action) => (event) => {
         event.preventDefault();
-        setQuizId(quizId);
-        navigate(`/current-quiz`);
+        if (action !== "No action possible") {
+            
+            setQuizId(quizId);
+            navigate(`/current-quiz`);
+        }
     }
 
     const fetchData = useCallback(async() => {
@@ -59,7 +62,7 @@ const AssignedQuiz = () => {
         if (params.field === 'action') {
             return (
                 <Button
-                    onClick={clickHandler(params.row.quizId)}
+                    onClick={clickHandler(params.row.quizId, params.row.action)}
                     variant='contained'
                 >
                     {params.row.action}


### PR DESCRIPTION
Current behaviour for clicking through to a Quiz on Assigned Quiz as lecturer or student takes you to the Quiz Attempt page regardless of status of quiz.

Clicking when "No Action Possible" is shown leads to the Quiz Attempt page which will be stuck with "Page Loading".

The fix is intended to prevent clickthrough for only this scenario.