### PR TITLE
Logic change to redirect unauthorised access to main menu

### DIFF
--- a/src/containers/Main/Main.js
+++ b/src/containers/Main/Main.js
@@ -15,13 +15,32 @@ import MainHeader from '../../components/MainHeader/MainHeader.js'
 import './Main.css';
 import Button from '@mui/material/Button';
 import { QuizProvider } from './CurrentQuiz/CurrentQuizContext.js';
+import {hasLecturerAccess} from '../../api/UserAPI.js'
 
 const Main = (props) => {
 
+    const [isLecturer, setIsLecturer] = useState(null); // State to manage lecturer access
+
     const clickHandler = (event) => {
         event.preventDefault();
+        setIsLecturer(null);
         return props.onLogout();
     }
+
+    const checkLecturerAccess = useCallback(async () => {
+        try {
+            const userId = localStorage.getItem('userId'); // Assuming userId is stored in localStorage
+            const access = await hasLecturerAccess(userId);
+            setIsLecturer(access);
+            console.log("lecturer access: " + access);
+        } catch (error) {
+            console.error("Error checking lecturer access: ", error);
+        }
+    }, []);
+
+    useEffect(() => {
+        checkLecturerAccess();
+    }, [checkLecturerAccess]);
 
     return (
         <div className='main_whole'>
@@ -33,17 +52,18 @@ const Main = (props) => {
                 <QuizProvider>
                     {/* MAIN SECTION SWITCHING */}
                     <Routes>
-                        <Route path="/" element = {<MainMenu/>} />
+                        <Route path="/" element = {<MainMenu isLecturer={isLecturer}/>} />
                         <Route path="/assigned-quiz" element = {<AssignedQuiz/>} />
                         <Route path="/past-quiz-results" element = {<PastQuizResults/>} />     
-                        <Route path="/current-quiz" element = {<CurrentQuiz/>} />      
-                        <Route path="/questions" element = {<QuestionBank/>} />
-                        <Route path="/quiz" element = {<QuizBank/>} />
-                        <Route path="/quiz-status" element = {<QuizStatus/>} />
-                        <Route path="/create-quiz" element = {<QuizCreation/>} />
-                        <Route path="/add-question" element = {<QuestionForm pageMode='add' />} />
-                        <Route path="/view-edit-question/:questionId" element = {<QuestionForm pageMode='viewEdit'/>} />
-                        <Route path="/current-quiz-result" element = {<CurrentQuizResult/>} />
+                        <Route path="/current-quiz" element = {<CurrentQuiz/>} />    
+                        <Route path="/current-quiz-result" element = {<CurrentQuizResult/>} />  
+                        {/* The Routes below are privileged to lecturers only */}
+                        <Route path="/questions" element = {  isLecturer? <QuestionBank/> : <Navigate to="/" replace />} />
+                        <Route path="/quiz" element = { isLecturer? <QuizBank/> : <Navigate to="/" replace />} />
+                        <Route path="/quiz-status" element = { isLecturer? <QuizStatus/>  : <Navigate to="/" replace />} />
+                        <Route path="/create-quiz" element = { isLecturer? <QuizCreation/> : <Navigate to="/" replace />} />
+                        <Route path="/add-question" element = { isLecturer? <QuestionForm pageMode='add' />  : <Navigate to="/" replace />} />
+                        <Route path="/view-edit-question/:questionId" element = { isLecturer? <QuestionForm pageMode='viewEdit'/>  : <Navigate to="/" replace />} />
                     </Routes>
                 </QuizProvider>
         </div>

--- a/src/containers/Main/MainMenu/MainMenu.js
+++ b/src/containers/Main/MainMenu/MainMenu.js
@@ -1,31 +1,14 @@
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import {Link} from 'react-router-dom';
-import React, {useEffect, useState, useCallback} from 'react';
-import {hasLecturerAccess} from '../../../api/UserAPI.js'
+import React from 'react';
+import CircularProgress from '@mui/material/CircularProgress';
 import './MainMenu.css'
 
-const MainMenu = () => {
+const MainMenu = (props) => {
 
-    const [isLecturer, setIsLecturer] = useState(null); // State to manage lecturer access
-
-    const checkLecturerAccess = useCallback(async () => {
-        try {
-            const userId = localStorage.getItem('userId'); // Assuming userId is stored in localStorage
-            const access = await hasLecturerAccess(userId);
-            setIsLecturer(access);
-            console.log("lecturer access: " + access);
-        } catch (error) {
-            console.error("Error checking lecturer access: ", error);
-        }
-    }, []);
-
-    useEffect(() => {
-        checkLecturerAccess();
-    }, [checkLecturerAccess]);
-
-    if (isLecturer === null) {
-        return <div>Loading...</div>; // Show a loading state while checking access
+    if (props.isLecturer === null) {
+        return <div><CircularProgress /><br/>Loading<br/></div>; // Show a loading state while checking access
     }
 
     return (
@@ -39,7 +22,7 @@ const MainMenu = () => {
 
             {/* Lecturer-Access functions */}
 
-            { isLecturer ? (<React.Fragment>
+            { props.isLecturer ? (<React.Fragment>
             <Button component={Link} to="/create-quiz" variant="contained" size="large">
                 Create Quiz
             </Button>


### PR DESCRIPTION
Logging out as a lecturer and logging back in as a student while on a lecturer-access page keeps you on the page after logging in.

This fix addresses this by adding redirect logic back to main menu.